### PR TITLE
Fix bug where king could wrongly be captured

### DIFF
--- a/src/main/java/copenhagen/GameLogic.java
+++ b/src/main/java/copenhagen/GameLogic.java
@@ -15,7 +15,6 @@ import java.util.LinkedList;
  */
 public class GameLogic{
     private static int GRID_SIZE = 11;
-    private static boolean kingWasCaptured = false;
     public static char[][] gameBoardArray;
 
     /**
@@ -24,7 +23,7 @@ public class GameLogic{
      * @return This function will return true if the piece can be moved, else false if it can not be moved.
      */
     public static boolean pieceCanMove(char piece, char turn) {
-        if ((piece == 'w' && turn == 'w') || (piece == 'b' && turn == 'b') || (piece == 'k' && turn == 'w')) {
+        if (piece == turn || (piece == 'k' && turn == 'w')) {
             return true;
         } else {
             return false;
@@ -59,15 +58,17 @@ public class GameLogic{
      */
 	public static void removeCapturedPieces(LinkedList<Integer> col, LinkedList<Integer> row) {
         GameBoard hBoard = Hnefatafl.getHBoard();
-	    for (int i = 0; i < col.size(); i++) {
-	        int c = col.get(i);
-	        int r = row.get(i);
-	        if (getPiece(c,r) == 'k') {
-                kingWasCaptured = true;
+        for (int i = 0; i < col.size(); i++) {
+            int c = col.get(i);
+            int r = row.get(i);
+            if (getPiece(c,r) == 'k') {
+                // Sandwiching a non-king piece captures it
+                // But the king is only captured if it is surrounded on all 4 (or 3 if the king is on an edge) sides
+                return;
             }
             gameBoardArray[c][r] = '0';
-			GameBoard.removeCapturedPiecesUI(c,r);
-		}
+            GameBoard.removeCapturedPiecesUI(c,r);
+        }
     }
 
     /**
@@ -160,22 +161,15 @@ public class GameLogic{
 	}
 
 	/**
-	 This function checks if there is a winner at the end of each turn
+	 This function checks to see if there is a winner at the end of each turn
 	 */
 	public static char checkWinner(char[][] gameBoard) {
-		char winner = '0';
-        if(kingWasCaptured) {
-        	kingWasCaptured = false;
-            winner = 'b';
-            return  winner;
-        }
-		// Check Full Surrounding of king for Attackers Win
 		for (int i = 1; i < gameBoard.length-1; i++) {
 			for (int j = 1; j < gameBoard.length-1; j++) {
 				if(gameBoard[i][j] == 'k') { // Found the king piece
 					if (gameBoard[i+1][j] == 'b' && gameBoard[i][j+1] == 'b' && gameBoard[i-1][j] == 'b' && gameBoard[i][j-1] == 'b' ) {
-						// King is entirely surrounded
-						winner = 'b';
+						// King is entirely surrounded so attackers win
+						return 'b';
 					}
 				}
 			}
@@ -184,8 +178,8 @@ public class GameLogic{
 		for (int i = 1; i < gameBoard.length-1; i++) {
 			if(gameBoard[i][0] == 'k') { // Found the king piece
 				if (gameBoard[i+1][0] == 'b' && gameBoard[i][1] == 'b' && gameBoard[i-1][0] == 'b') {
-					// King is surrounded on left edge
-					winner = 'b';
+					// King is surrounded on the left edge so attackers win
+					return 'b';
 				}
 			}
 		}
@@ -193,8 +187,8 @@ public class GameLogic{
 		for (int i = 1; i < gameBoard.length-1; i++) {
 			if(gameBoard[i][10] == 'k') { // Found the king piece
 				if (gameBoard[i+1][10] == 'b' && gameBoard[i][9] == 'b' && gameBoard[i-1][10] == 'b') {
-					// King is surrounded on right edge
-					winner = 'b';
+					// King is surrounded on the right edge so attackers win
+					return 'b';
 				}
 			}
 		}
@@ -202,8 +196,8 @@ public class GameLogic{
 		for (int i = 1; i < gameBoard.length-1; i++) {
 			if(gameBoard[10][i] == 'k') { // Found the king piece
 				if (gameBoard[10][i+1] == 'b' && gameBoard[9][i] == 'b' && gameBoard[10][i-1] == 'b') {
-					// King is surrounded on bottom edge
-					winner = 'b';
+					// King is surrounded on the bottom edge so attackers win
+					return 'b';
 				}
 			}
 		}
@@ -211,17 +205,18 @@ public class GameLogic{
 		for (int i = 1; i < gameBoard.length-1; i++) {
 			if(gameBoard[0][i] == 'k') { // Found the king piece
 				if (gameBoard[0][i+1] == 'b' && gameBoard[1][i] == 'b' && gameBoard[0][i-1] == 'b') {
-					// King is surrounded on bottom edge
-					winner = 'b';
+					// King is surrounded on the bottom edge so attackers win
+					return 'b';
 				}
 			}
 		}
 		// Check Corners for Defenders Win
 		if (gameBoard[0][0] == 'k' || gameBoard[0][10] == 'k' || gameBoard[10][0] == 'k' || gameBoard[10][10] == 'k') {
-			// King is in one of the corners
-			winner = 'w';
+			// King has reached one of the corners so defenders win
+			return 'w';
 		}
-		return winner;
+        // There is not a winner yet so continue playing
+		return '0';
 	}
 
     /**

--- a/src/main/java/copenhagen/Hnefatafl.java
+++ b/src/main/java/copenhagen/Hnefatafl.java
@@ -38,6 +38,8 @@ public class Hnefatafl {
 	private static int turnCount = 1;
 	public static char turn = 'b';
 	private static GameBoard hBoard;
+  private static GameLogic hLogic;
+  private static SideBar sBar;
 	private static int[] primaryColor = {244,164,96};
 	private static int[] secondaryColor = {139,69,19};
 	private static int[] letteringColor = {0,0,0};
@@ -77,12 +79,12 @@ public class Hnefatafl {
 		hBoard = new GameBoard(boardSize, primaryColor, secondaryColor, specialColor);
 		board = hBoard.getBoard();
 		pieceLayout = GameLogic.getGameBoardArray();
-		SideBar sBar = new SideBar(primaryColor, secondaryColor, letteringColor);
+    sBar = new SideBar(primaryColor, secondaryColor, letteringColor);
 		side = sBar.getSideBar();
 		BottomBar bBar = new BottomBar(primaryColor, letteringColor, turn, turnCount);
 		bottom = bBar.getBottomBar();
-        MenuBar menu = new MenuBar();
-        menuBar = menu.getMenuBar();
+    MenuBar menu = new MenuBar();
+    menuBar = menu.getMenuBar();
 		turnCount = 0;
 		turn = 'b';
 		selectedLoc = new BoardLocation();
@@ -348,9 +350,9 @@ public class Hnefatafl {
 
     /**
      * This function finds all the pieces that will be captured on the board by the move just completed.
-     * @param piece This parameter is the piece that getting moved.
-     * @param col This parameter is which column the piece will be at after it is moved.
-     * @param row This parameter is which row the piece will be at after it is moved.
+     * @param piece This parameter is the piece that is getting moved.
+     * @param col This parameter is the column that the piece will be in after it is moved.
+     * @param row This parameter is the row that the piece will be in after it is moved.
      */
     public static void findCapturedPieces(char piece, int col, int row) {
 	    char capturablePiece;


### PR DESCRIPTION
This fixes a bug that caused the king to be captured when it is just
sandwiched, the way all non-king pieces are captured. To capture the
king, it must be surrounded on all 4 sides or all 3 sides when the king
is on an edge