### PR TITLE
Integrates Black-/White-Start Menu and Fixes Magic Numbers

### DIFF
--- a/src/main/java/copenhagen/BlackWhiteStart.java
+++ b/src/main/java/copenhagen/BlackWhiteStart.java
@@ -9,12 +9,12 @@ import java.awt.event.*;
  * (black or white) at the start of a game.  Note: The attacker always gets the first turn.
  */
 public class BlackWhiteStart {
-    JFrame _blackWhiteFrame = new JFrame("Pick a color to start the attack"); // creates frame/window
-    JPanel _blackWhitePanel = new JPanel(); // one single flow panel
-    JButton _blackButton = new JButton("Black");
-    JButton _whiteButton = new JButton("White");
+    private JFrame _blackWhiteFrame = new JFrame("Pick a color to start the attack"); // creates frame/window
+    private JPanel _blackWhitePanel = new JPanel(); // one single flow panel
+    private JButton _blackButton = new JButton("Black");
+    private JButton _whiteButton = new JButton("White");
+    private static int boardSize = 11;
 
-    boolean blackStart;
 
     /**
      * This function will create the JFrame that will ask the user which side they want to go first.
@@ -48,22 +48,28 @@ public class BlackWhiteStart {
     }
 
     /**
-     * This is a button listener for when the _blackButton button is clicked and will set the blackStart boolean to true.
+     * This is a button listener for when the _blackButton button is clicked for the black pieces to start as the attackers.  This is implemented as the default state.
      */
     class BlackListener implements ActionListener {
         public void actionPerformed(ActionEvent e) {
-            blackStart = true;
-            // TODO: Add code to start game
+            Hnefatafl.blackStart();
+            _blackWhiteFrame.dispose();
+            GameLogic.setStartingPieces(boardSize);
+            Hnefatafl.setUpGameBoard();
+            Hnefatafl.displayGameBoard();
         }
     }
 
     /**
-     * This is a button listener for when the _whiteButton button is clicked and will set the blackStart boolean to false.
+     * This is a button listener for when the _whiteButton button is clicked for the white pieces to start as the attackers.
      */
     class WhiteListener implements ActionListener {
         public void actionPerformed(ActionEvent e) {
-            blackStart = false;
-            // TODO: Add code to start game
+            Hnefatafl.whiteStart();
+            _blackWhiteFrame.dispose();
+            GameLogic.setStartingPieces(boardSize);
+            Hnefatafl.setUpGameBoard();
+            Hnefatafl.displayGameBoard();
         }
     }
 }

--- a/src/main/java/copenhagen/BottomBar.java
+++ b/src/main/java/copenhagen/BottomBar.java
@@ -13,6 +13,11 @@ public class BottomBar {
     private JPanel bottom;
     private static JLabel turn;
     private static JLabel turnCount;
+    private static char attackers = 'b';
+	private static char defenders = 'w';
+	private static char king = 'k';
+	private static char empty = '0';
+	private static char restricted = 'c';
 
     /**
      * This is called when creating the bottom bar JPanel.
@@ -40,13 +45,13 @@ public class BottomBar {
 
     /**
      * This function displays who is starting based on the parameter given.
-     * @param c This tells which person starts, 'b' denoting black and 'w' denoting white.
+     * @param c This tells which person starts, attackers or defenders
      */
     private void setTurn(char c) {
-        if (c == 'b') {
+        if (c == attackers) {
             turn = new JLabel("Turn: Attackers");
         }
-        else if (c == 'w') {
+        else if (c == defenders) {
             turn = new JLabel("Turn: Defenders");
         }
         turn.setForeground(letteringColor);
@@ -76,10 +81,10 @@ public class BottomBar {
      * @param i This parameter is the current turn number.
      */
     public static void updateTurnInfo(char c, int i) {
-        if (c == 'b') {
+        if (c == attackers) {
             turn.setText("Turn: Attackers");
         }
-        else if (c == 'w') {
+        else if (c == defenders) {
             turn.setText("Turn: Defenders");
         }
         turnCount.setText("Turn Number: " + i);

--- a/src/main/java/copenhagen/FinalMenu.java
+++ b/src/main/java/copenhagen/FinalMenu.java
@@ -9,7 +9,7 @@ import java.awt.event.ActionListener;
  * This class is used for displaying the options a user has after a game of hnefatafl has finished.
  */
 public class FinalMenu {
-	
+
 	private JFrame menuFrame;
 	private JFrame exitWindow;
 	private JPanel menu;
@@ -19,67 +19,72 @@ public class FinalMenu {
 	private JLabel text;
 	private JLabel winnerText;
 	private MainMenu start;
-	
+	private static char attackers = 'b';
+	private static char defenders = 'w';
+	private static char king = 'k';
+	private static char empty = '0';
+	private static char restricted = 'c';
+
 	/**
 	 * This function calls a function to create the final menu.
 	 */
 	public FinalMenu(char winningSide) {
 		createMenu(winningSide);
 	}
-	
+
 	/**
 	 * This function creates and displays the final menu after a game has finished.
 	 */
 	private void createMenu(char winningSide) {
 		String winner;
-		if (winningSide == 'w') {
+		if (winningSide == defenders) {
 			winner = "DEFENDERS";
 		} else {
 			winner = "ATTACKERS";
 		}
-		
+
 		menuFrame = new JFrame();
 		menuFrame.setSize(new Dimension(400, 200));
-		
+
 		menu = new JPanel();
 		buttonPanel = new JPanel();
-		
+
 		text = new JLabel("Game Over!\n\n");
 		text.setFont(new Font("Courier", Font.PLAIN, 30));
 		winnerText = new JLabel(winner + " WIN\n\n");
 		winnerText.setFont(new Font("Courier", Font.PLAIN, 40));
-		
+
 		addButtons();
-		
+
 		menu.add(text, BorderLayout.CENTER);
 		menu.add(winnerText, BorderLayout.CENTER);
 		menu.add(buttonPanel, BorderLayout.SOUTH);
 		menuFrame.add(menu, BorderLayout.CENTER);
-		
+
 		showMenu();
-		
+
 	}
 	private void showMenu() {
 		menuFrame.setLocationRelativeTo(null);
 		menuFrame.setVisible(true);
 		menuFrame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 	}
-	
+
 	private void addButtons() {
 		newGameBtn = new JButton("New Game");
 		newGameBtn.addActionListener(new newListener());
-		
+
 		mainMenuBtn = new JButton("Exit Game");
 		mainMenuBtn.addActionListener(new mainMenuListener());
-		
+
 		buttonPanel.add(newGameBtn);
 		buttonPanel.add(mainMenuBtn);
-		
+
 	}
-	
-	
-	
-	
+
+
+
+
 	/**
 	 *This is a button listener for when the new game button is clicked. It will prompt the user to confirm.
 	 *If the user confirms, it will class a new game function to reset the board and begin a new game.
@@ -95,7 +100,7 @@ public class FinalMenu {
 			if (n == 1) {
 				return;
 			}
-			
+
 		}
 	}
 	/**
@@ -112,7 +117,7 @@ public class FinalMenu {
 			if (n == 1) {
 				return;
 			}
-			
+
 		}
 	}
 }

--- a/src/main/java/copenhagen/GameBoard.java
+++ b/src/main/java/copenhagen/GameBoard.java
@@ -13,9 +13,9 @@ import java.awt.event.*;
  * the second dimension represents the column.
  * The char value represents the piece type:
  * '0' for empty
- * 'c' for the throne and the corner squares (the five restricted squares)
- * 'w' for a white piece
- * 'b' for a black piece
+ * restricted for the throne and the corner squares (the five restricted squares)
+ * 'w' for a defending piece
+ * 'b' for an attacking piece
  * 'k' for the king piece
  */
 public class GameBoard {
@@ -27,6 +27,11 @@ public class GameBoard {
 	Color specialColor; //color of the center and corners
 	private JButton[][] boardSquares;
 	private JPanel board;
+	private static char attackers = 'b';
+	private static char defenders = 'w';
+	private static char king = 'k';
+	private static char empty = '0';
+	private static char restricted = 'c';
 
     /**
      * This is called when creating the game board JPanel.
@@ -136,7 +141,7 @@ public class GameBoard {
      */
 	public void unhighlightButton(int col, int row) {
         char[][] pieceLocations = GameLogic.getGameBoardArray();
-		if (pieceLocations[col][row] == 'c') {
+		if (pieceLocations[col][row] == restricted) {
 		    boardSquares[col][row].setBackground(specialColor);
 
         }
@@ -167,15 +172,15 @@ public class GameBoard {
 	    try {
 	        Image img;
 	        ImageIcon icon;
-            if (pieceName == 'b') {
+            if (pieceName == attackers) {
                 img = ImageIO.read(getClass().getResource("images/blackpiece.png"));
                 icon = new ImageIcon(img);
                 button.setIcon(icon);
-            } else if (pieceName == 'w') {
+            } else if (pieceName == defenders) {
                 img = ImageIO.read(getClass().getResource("images/whitepiece.png"));
                 icon = new ImageIcon(img);
                 button.setIcon(icon);
-            } else if (pieceName == 'k') {
+            } else if (pieceName == king) {
                 img = ImageIO.read(getClass().getResource("images/king.png"));
                 icon = new ImageIcon(img);
                 button.setIcon(icon);

--- a/src/main/java/copenhagen/GameBoard.java
+++ b/src/main/java/copenhagen/GameBoard.java
@@ -173,15 +173,15 @@ public class GameBoard {
 	        Image img;
 	        ImageIcon icon;
             if (pieceName == attackers) {
-                img = ImageIO.read(getClass().getResource("images/blackpiece.png"));
+                img = ImageIO.read(getClass().getResource(Hnefatafl.getAttackPieceAddr()));
                 icon = new ImageIcon(img);
                 button.setIcon(icon);
             } else if (pieceName == defenders) {
-                img = ImageIO.read(getClass().getResource("images/whitepiece.png"));
+                img = ImageIO.read(getClass().getResource(Hnefatafl.getDefendPieceAddr()));
                 icon = new ImageIcon(img);
                 button.setIcon(icon);
             } else if (pieceName == king) {
-                img = ImageIO.read(getClass().getResource("images/king.png"));
+                img = ImageIO.read(getClass().getResource(Hnefatafl.getKingPieceAddr()));
                 icon = new ImageIcon(img);
                 button.setIcon(icon);
             }

--- a/src/main/java/copenhagen/GameLogic.java
+++ b/src/main/java/copenhagen/GameLogic.java
@@ -9,13 +9,18 @@ import java.util.LinkedList;
  * The char value represents the piece type:
  * '0' for empty
  * 'c' for the throne and the corner squares (the five restricted squares)
- * 'w' for a white piece
- * 'b' for a black piece
+ * 'w' for a defending piece
+ * 'b' for an attacking piece
  * 'k' for the king piece
  */
 public class GameLogic{
     private static int GRID_SIZE = 11;
     public static char[][] gameBoardArray;
+    private static char attackers = 'b';
+	private static char defenders = 'w';
+	private static char king = 'k';
+	private static char empty = '0';
+	private static char restricted = 'c';
 
     /**
      * This function checks whether a piece is allowed to be currently moved.
@@ -23,7 +28,7 @@ public class GameLogic{
      * @return This function will return true if the piece can be moved, else false if it can not be moved.
      */
     public static boolean pieceCanMove(char piece, char turn) {
-        if (piece == turn || (piece == 'k' && turn == 'w')) {
+        if (piece == turn || (piece == king && turn == defenders)) {
             return true;
         } else {
             return false;
@@ -60,12 +65,12 @@ public class GameLogic{
         for (int i = 0; i < col.size(); i++) {
             int c = col.get(i);
             int r = row.get(i);
-            if (getPiece(c,r) == 'k') {
+            if (getPiece(c,r) == king) {
                 // Sandwiching a non-king piece captures it
                 // But the king is only captured if it is surrounded on all 4 (or 3 if the king is on an edge) sides
                 return;
             }
-            gameBoardArray[c][r] = '0';
+            gameBoardArray[c][r] = empty;
             GameBoard.removeCapturedPiecesUI(c,r);
         }
     }
@@ -82,20 +87,20 @@ public class GameLogic{
         //Initialize to null char
         for (int i = 0; i < s.length; i++) {
             for (int j = 0; j < s[i].length; j++) {
-                s[i][j] = '0';
+                s[i][j] = empty;
             }
         }
 
         if (GRID_SIZE==11) {
-            s[0][3] = s[0][4] = s[0][5] = s[0][6] = s[0][7] = s[1][5] = 'b';
-            s[3][0] = s[4][0] = s[5][0] = s[6][0] = s[7][0] = s[5][1] = 'b';
-            s[10][3] = s[10][4] = s[10][5] = s[10][6] = s[10][7] = s[9][5] = 'b';
-            s[3][10] = s[4][10] = s[5][10] = s[6][10] = s[7][10] = s[5][9] = 'b';
+            s[0][3] = s[0][4] = s[0][5] = s[0][6] = s[0][7] = s[1][5] = attackers;
+            s[3][0] = s[4][0] = s[5][0] = s[6][0] = s[7][0] = s[5][1] = attackers;
+            s[10][3] = s[10][4] = s[10][5] = s[10][6] = s[10][7] = s[9][5] = attackers;
+            s[3][10] = s[4][10] = s[5][10] = s[6][10] = s[7][10] = s[5][9] = attackers;
 
-            s[3][5] = s[4][4] = s[4][5] = s[4][6] = s[5][3] = s[5][4] = 'w';
-            s[5][6] = s[5][7] = s[6][4] = s[6][5] = s[6][6] = s[7][5] = 'w';
-            s[0][0] = s[0][10] = s[10][0] = s[10][10] = s[5][5] = 'c';
-            s[5][5] = 'k';
+            s[3][5] = s[4][4] = s[4][5] = s[4][6] = s[5][3] = s[5][4] = defenders;
+            s[5][6] = s[5][7] = s[6][4] = s[6][5] = s[6][6] = s[7][5] = defenders;
+            s[0][0] = s[0][10] = s[10][0] = s[10][10] = s[5][5] = restricted;
+            s[5][5] = king;
         }
         gameBoardArray = s;
         return s;
@@ -121,36 +126,36 @@ public class GameLogic{
 	public static boolean[][] getValidMoves(char piece, int col, int row){
 		boolean[][] validSpaces = new boolean[GRID_SIZE][GRID_SIZE];
 		for(int i=col+1; i<GRID_SIZE; i++){//check move right
-			if((gameBoardArray[i][row] == '0') || (piece == 'k' && gameBoardArray[i][row] == 'c')){
+			if((gameBoardArray[i][row] == empty) || (piece == king && gameBoardArray[i][row] == restricted)){
 				validSpaces[i][row] = true;
-			} else if (piece != 'k' && gameBoardArray[i][row] == 'c'){
+			} else if (piece != king && gameBoardArray[i][row] == restricted){
 				validSpaces[i][row] = false;
 			} else {
 				break;
 			}
 		}
 		for(int i=col-1; i>=0; i--){//check move left
-			if((gameBoardArray[i][row] == '0') || (piece == 'k' && gameBoardArray[i][row] == 'c')){
+			if((gameBoardArray[i][row] == empty) || (piece == king && gameBoardArray[i][row] == restricted)){
 				validSpaces[i][row] = true;
-			}else if (piece != 'k' && gameBoardArray[i][row] == 'c'){
+			}else if (piece != king && gameBoardArray[i][row] == restricted){
 				validSpaces[i][row] = false;
 			}else{
 				break;
 			}
 		}
 		for(int i=row+1; i<GRID_SIZE; i++){//check move down
-			if((gameBoardArray[col][i] == '0') || (piece == 'k' && gameBoardArray[col][i] == 'c')){
+			if((gameBoardArray[col][i] == empty) || (piece == king && gameBoardArray[col][i] == restricted)){
 				validSpaces[col][i] = true;
-			}else if (piece != 'k' && gameBoardArray[col][i] == 'c'){
+			}else if (piece != king && gameBoardArray[col][i] == restricted){
 				validSpaces[col][i] = false;
 			}else{
 				break;
 			}
 		}
 		for(int i=row-1; i>=0; i--){//check move up
-			if((gameBoardArray[col][i] == '0') || (piece == 'k' && gameBoardArray[col][i] == 'c')){
+			if((gameBoardArray[col][i] == empty) || (piece == king && gameBoardArray[col][i] == restricted)){
 				validSpaces[col][i] = true;
-			}else if (piece != 'k' && gameBoardArray[col][i] == 'c'){
+			}else if (piece != king && gameBoardArray[col][i] == restricted){
 			 	validSpaces[col][i] = false;
 			}else{
 				break;
@@ -165,77 +170,77 @@ public class GameLogic{
 	public static char checkWinner() {
         //boolean defendersSurrounded = false;
         //boolean foundExit = false;
-        
+
         // Check if king is entirely surrounded
 		for (int i = 1; i < gameBoardArray.length-1; i++) {
 			for (int j = 1; j < gameBoardArray.length-1; j++) {
-				if(gameBoardArray[i][j] == 'k') { // Found the king piece
-					if (gameBoardArray[i+1][j] == 'b' && gameBoardArray[i][j+1] == 'b' && gameBoardArray[i-1][j] == 'b' && gameBoardArray[i][j-1] == 'b' ) {
+				if(gameBoardArray[i][j] == king) { // Found the king piece
+					if (gameBoardArray[i+1][j] == attackers && gameBoardArray[i][j+1] == attackers && gameBoardArray[i-1][j] == attackers && gameBoardArray[i][j-1] == attackers ) {
 						// King is entirely surrounded so attackers win
-						return 'b';
+						return attackers;
 					}
 				}
 			}
 		}
 		// Check Corners for Defenders Win
-		if (gameBoardArray[0][0] == 'k' || gameBoardArray[0][10] == 'k' || gameBoardArray[10][0] == 'k' || gameBoardArray[10][10] == 'k') {
+		if (gameBoardArray[0][0] == king || gameBoardArray[0][10] == king || gameBoardArray[10][0] == king || gameBoardArray[10][10] == king) {
 			// King has reached one of the corners so defenders win
-			return 'w';
+			return defenders;
 		}
         // Check Left of Throne for Attackers Win
-        if(gameBoardArray[5][4] == 'k') {
-            if (gameBoardArray[5][3] == 'b' && gameBoardArray[4][4] == 'b' && gameBoardArray[6][4] == 'b') {
+        if(gameBoardArray[5][4] == king) {
+            if (gameBoardArray[5][3] == attackers && gameBoardArray[4][4] == attackers && gameBoardArray[6][4] == attackers) {
                 // King is surrounded to the left of the throne
-                return 'b';
+                return attackers;
             }
         }
         // Check Right of Throne for Attackers Win
-        if(gameBoardArray[5][6] == 'k') {
-            if (gameBoardArray[5][7] == 'b' && gameBoardArray[4][6] == 'b' && gameBoardArray[6][6] == 'b') {
+        if(gameBoardArray[5][6] == king) {
+            if (gameBoardArray[5][7] == attackers && gameBoardArray[4][6] == attackers && gameBoardArray[6][6] == attackers) {
                 // King is surrounded to the right of the throne
-                return 'b';
+                return attackers;
             }
         }
         // Check Below Throne for Attackers Win
-        if(gameBoardArray[6][5] == 'k') {
-            if (gameBoardArray[7][5] == 'b' && gameBoardArray[6][4] == 'b' && gameBoardArray[6][6] == 'b') {
+        if(gameBoardArray[6][5] == king) {
+            if (gameBoardArray[7][5] == attackers && gameBoardArray[6][4] == attackers && gameBoardArray[6][6] == attackers) {
                 // King is surrounded below the throne
-                return 'b';
+                return attackers;
             }
         }
         // Check Above Throne for Attackers Win
-        if(gameBoardArray[4][5] == 'k') {
-            if (gameBoardArray[3][5] == 'b' && gameBoardArray[4][4] == 'b' && gameBoardArray[4][6] == 'b') {
+        if(gameBoardArray[4][5] == king) {
+            if (gameBoardArray[3][5] == attackers && gameBoardArray[4][4] == attackers && gameBoardArray[4][6] == attackers) {
                 // King is surrounded above the throne
-                return 'b';
+                return attackers;
             }
         }
-        
+
         /**
          Doesn't work correctly
-        
+
         // Check if Attackers have entirely surrounded Defenders
         for (int i = 0; i < gameBoardArray.length; i++) {
              for (int j = 0; j < gameBoardArray.length; j++) {
-                 if(gameBoardArray[i][j] == 'b') {
+                 if(gameBoardArray[i][j] == attackers) {
                      // Look for another Attacker blocking the Defenders in this column
                      for (int n = 0; n < gameBoardArray.length; n++) {
-                         if (gameBoardArray[n][j] == 'w' || gameBoardArray[n][j] == 'k')
+                         if (gameBoardArray[n][j] == defenders || gameBoardArray[n][j] == king)
                              defendersSurrounded = false;
-                         else if (gameBoardArray[n][j] == 'b')
+                         else if (gameBoardArray[n][j] == attackers)
                              defendersSurrounded = true;
                          if (defendersSurrounded == false && n == gameBoardArray.length - 1) {
-                             return '0';
+                             return empty;
                          }
                      }
                      // Look for another Attacker blocking the Defenders in this row
                      for (int n = 0; n < gameBoardArray.length; n++) {
-                         if (gameBoardArray[i][n] == 'w' || gameBoardArray[i][n] == 'k')
+                         if (gameBoardArray[i][n] == defenders || gameBoardArray[i][n] == king)
                              defendersSurrounded = false;
-                         else if (gameBoardArray[n][j] == 'b')
+                         else if (gameBoardArray[n][j] == attackers)
                              defendersSurrounded = true;
                          if (defendersSurrounded == false && n == gameBoardArray.length - 1){
-                             return '0';
+                             return empty;
                          }
                      }
                  }
@@ -245,9 +250,9 @@ public class GameLogic{
         if (!foundExit)
             return 'b';
         */
-        
+
         // There is not a winner yet so continue playing
-		return '0';
+		return empty;
 	}
 
     /**
@@ -265,15 +270,15 @@ public class GameLogic{
 			(startCol==GRID_SIZE-1 && startRow==GRID_SIZE-1) ||
 			(startCol==0 && startRow==GRID_SIZE-1) ||
 			(startCol==GRID_SIZE-1 && startRow==0) || (startCol==5 && startRow==5)) {
-			updateGameBoard(startCol, startRow, 'c');
+			updateGameBoard(startCol, startRow, restricted);
 
 		}else{
-            updateGameBoard(startCol, startRow, '0');
+            updateGameBoard(startCol, startRow, empty);
         }
         updateGameBoard(destCol, destRow, pieceType);
         findCapturedPieces(pieceType, destCol, destRow);
 	}
-	
+
 	/**
      * This function is called to determine if there is a shieldwall during a move by a piece.
      * TODO: Refactor this code!
@@ -282,9 +287,9 @@ public class GameLogic{
      * @param row This is the row of where the piece will be going.
      * @param capturePiece This is the kind of piece that is allowed to be captured.
      * @param helperPiece This is the kind of piece that helps in a capture:
-     *                     i.e. another black piece if piece == 'b'
-     *                          the king piece if piece == 'w'
-     *                          a white piece if piece == 'k'
+     *                     i.e. another black piece if piece is black
+     *                          the king piece if piece == defenders
+     *                          another white piece if piece is white
      */
     private static void findShieldwall(char piece, int col, int row, char capturePiece, char helperPiece) {
         LinkedList<Integer> capturedPieceCol = new LinkedList<>();
@@ -294,7 +299,7 @@ public class GameLogic{
         if (col == 0) {
             if (row <= 7) {
                 for (int i = row+1; i < 11; i++) {
-                    if (gameBoardArray[col][i] == '0') {
+                    if (gameBoardArray[col][i] == empty) {
                         break;
                     }
                     else if (gameBoardArray[col][i] == capturePiece && (gameBoardArray[col+1][i] == piece || gameBoardArray[col+1][i] == helperPiece)) {
@@ -302,7 +307,7 @@ public class GameLogic{
                         capturedPieceRow.add(i);
                         counter++;
                     }
-                    else if (gameBoardArray[col][i] == piece || gameBoardArray[col][i] == helperPiece || gameBoardArray[col][i] == 'c') {
+                    else if (gameBoardArray[col][i] == piece || gameBoardArray[col][i] == helperPiece || gameBoardArray[col][i] == restricted) {
                         if (counter >= 2) {
                             removeCapturedPieces(capturedPieceCol, capturedPieceRow);
                         }
@@ -312,7 +317,7 @@ public class GameLogic{
             }
             if (row >= 3) {
                 for (int i = row-1; i >= 0; i--) {
-                    if (gameBoardArray[col][i] == '0') {
+                    if (gameBoardArray[col][i] == empty) {
                         break;
                     }
                     else if (gameBoardArray[col][i] == capturePiece && (gameBoardArray[col+1][i] == piece || gameBoardArray[col+1][i] == helperPiece)) {
@@ -320,7 +325,7 @@ public class GameLogic{
                         capturedPieceRow.add(i);
                         counter++;
                     }
-                    else if (gameBoardArray[col][i] == piece || gameBoardArray[col][i] == helperPiece || gameBoardArray[col][i] == 'c') {
+                    else if (gameBoardArray[col][i] == piece || gameBoardArray[col][i] == helperPiece || gameBoardArray[col][i] == restricted) {
                         if (counter >= 2) {
                             removeCapturedPieces(capturedPieceCol, capturedPieceRow);
                         }
@@ -333,7 +338,7 @@ public class GameLogic{
         if (col == GRID_SIZE-1) {
             if (row <= 7) {
                 for (int i = row+1; i < 11; i++) {
-                    if (gameBoardArray[col][i] == '0') {
+                    if (gameBoardArray[col][i] == empty) {
                         break;
                     }
                     else if (gameBoardArray[col][i] == capturePiece && (gameBoardArray[col-1][i] == piece || gameBoardArray[col-1][i] == helperPiece)) {
@@ -341,7 +346,7 @@ public class GameLogic{
                         capturedPieceRow.add(i);
                         counter++;
                     }
-                    else if (gameBoardArray[col][i] == piece || gameBoardArray[col][i] == helperPiece || gameBoardArray[col][i] == 'c') {
+                    else if (gameBoardArray[col][i] == piece || gameBoardArray[col][i] == helperPiece || gameBoardArray[col][i] == restricted) {
                         if (counter >= 2) {
                             removeCapturedPieces(capturedPieceCol, capturedPieceRow);
                         }
@@ -351,7 +356,7 @@ public class GameLogic{
             }
             if (row >= 3) {
                 for (int i = row-1; i >= 0; i--) {
-                    if (gameBoardArray[col][i] == '0') {
+                    if (gameBoardArray[col][i] == empty) {
                         break;
                     }
                     else if (gameBoardArray[col][i] == capturePiece && (gameBoardArray[col-1][i] == piece || gameBoardArray[col-1][i] == helperPiece)) {
@@ -359,7 +364,7 @@ public class GameLogic{
                         capturedPieceRow.add(i);
                         counter++;
                     }
-                    else if (gameBoardArray[col][i] == piece || gameBoardArray[col][i] == helperPiece || gameBoardArray[col][i] == 'c') {
+                    else if (gameBoardArray[col][i] == piece || gameBoardArray[col][i] == helperPiece || gameBoardArray[col][i] == restricted) {
                         if (counter >= 2) {
                             removeCapturedPieces(capturedPieceCol, capturedPieceRow);
                         }
@@ -372,7 +377,7 @@ public class GameLogic{
         if (row == 0) {
             if (col <= 7) {
                 for (int i = col+1; i < 11; i++) {
-                    if (gameBoardArray[i][row] == '0') {
+                    if (gameBoardArray[i][row] == empty) {
                         break;
                     }
                     else if (gameBoardArray[i][row] == capturePiece && (gameBoardArray[i][row+1] == piece || gameBoardArray[i][row+1] == helperPiece)) {
@@ -380,7 +385,7 @@ public class GameLogic{
                         capturedPieceRow.add(row);
                         counter++;
                     }
-                    else if (gameBoardArray[i][row] == piece || gameBoardArray[i][row] == helperPiece || gameBoardArray[i][row] == 'c') {
+                    else if (gameBoardArray[i][row] == piece || gameBoardArray[i][row] == helperPiece || gameBoardArray[i][row] == restricted) {
                         if (counter >= 2) {
                             removeCapturedPieces(capturedPieceCol, capturedPieceRow);
                         }
@@ -390,7 +395,7 @@ public class GameLogic{
             }
             if (col >= 3) {
                 for (int i = col-1; i >= 0; i--) {
-                    if (gameBoardArray[i][row] == '0') {
+                    if (gameBoardArray[i][row] == empty) {
                         break;
                     }
                     else if (gameBoardArray[i][row] == capturePiece && (gameBoardArray[i][row+1] == piece || gameBoardArray[i][row+1] == helperPiece)) {
@@ -398,7 +403,7 @@ public class GameLogic{
                         capturedPieceRow.add(row);
                         counter++;
                     }
-                    else if (gameBoardArray[i][row] == piece || gameBoardArray[i][row] == helperPiece || gameBoardArray[i][row] == 'c') {
+                    else if (gameBoardArray[i][row] == piece || gameBoardArray[i][row] == helperPiece || gameBoardArray[i][row] == restricted) {
                         if (counter >= 2) {
                             removeCapturedPieces(capturedPieceCol, capturedPieceRow);
                         }
@@ -411,7 +416,7 @@ public class GameLogic{
         if (row == GRID_SIZE-1) {
             if (col <= 7) {
                 for (int i = col+1; i < 11; i++) {
-                    if (gameBoardArray[i][row] == '0') {
+                    if (gameBoardArray[i][row] == empty) {
                         break;
                     }
                     else if (gameBoardArray[i][row] == capturePiece && (gameBoardArray[i][row-1] == piece || gameBoardArray[i][row-1] == helperPiece)) {
@@ -419,7 +424,7 @@ public class GameLogic{
                         capturedPieceRow.add(row);
                         counter++;
                     }
-                    else if (gameBoardArray[i][row] == piece || gameBoardArray[i][row] == helperPiece || gameBoardArray[i][row] == 'c') {
+                    else if (gameBoardArray[i][row] == piece || gameBoardArray[i][row] == helperPiece || gameBoardArray[i][row] == restricted) {
                         if (counter >= 2) {
                             removeCapturedPieces(capturedPieceCol, capturedPieceRow);
                         }
@@ -429,7 +434,7 @@ public class GameLogic{
             }
             if (col >= 3) {
                 for (int i = col-1; i >= 0; i--) {
-                    if (gameBoardArray[i][row] == '0') {
+                    if (gameBoardArray[i][row] == empty) {
                         break;
                     }
                     else if (gameBoardArray[i][row] == capturePiece && (gameBoardArray[i][row-1] == piece || gameBoardArray[i][row-1] == helperPiece)) {
@@ -437,7 +442,7 @@ public class GameLogic{
                         capturedPieceRow.add(row);
                         counter++;
                     }
-                    else if (gameBoardArray[i][row] == piece || gameBoardArray[i][row] == helperPiece || gameBoardArray[i][row] == 'c') {
+                    else if (gameBoardArray[i][row] == piece || gameBoardArray[i][row] == helperPiece || gameBoardArray[i][row] == restricted) {
                         if (counter >= 2) {
                             removeCapturedPieces(capturedPieceCol, capturedPieceRow);
                         }
@@ -456,43 +461,43 @@ public class GameLogic{
      */
     public static void findCapturedPieces(char piece, int col, int row) {
 	    char capturablePiece;
-	    char kingPiece = 'b';
+	    char kingPiece = attackers;
 	    char helperPiece;
 	    LinkedList<Integer> capturedPieceCol = new LinkedList<>();
         LinkedList<Integer> capturedPieceRow = new LinkedList<>();
-	    if (piece == 'b') {
-	        capturablePiece = 'w';
-            kingPiece = 'k';
-            helperPiece = 'b';
+	    if (piece == attackers) {
+	        capturablePiece = defenders;
+            kingPiece = king;
+            helperPiece = attackers;
         }
-        else if (piece == 'w'){
-            capturablePiece = 'b';
-            helperPiece = 'k';
+        else if (piece == defenders){
+            capturablePiece = attackers;
+            helperPiece = king;
         }
         else {
-            capturablePiece = 'b';
-            helperPiece = 'w';
+            capturablePiece = attackers;
+            helperPiece = defenders;
         }
         if (col-2 >= 0) {
-            if ((gameBoardArray[col - 1][row] == capturablePiece || gameBoardArray[col - 1][row] == kingPiece) && (gameBoardArray[col - 2][row] == piece || gameBoardArray[col - 2][row] == helperPiece || gameBoardArray[col - 2][row] == 'c')) {
+            if ((gameBoardArray[col - 1][row] == capturablePiece || gameBoardArray[col - 1][row] == kingPiece) && (gameBoardArray[col - 2][row] == piece || gameBoardArray[col - 2][row] == helperPiece || gameBoardArray[col - 2][row] == restricted)) {
                 capturedPieceCol.add(col - 1);
                 capturedPieceRow.add(row);
             }
         }
         if (col+2 <= GRID_SIZE-1) {
-            if ((gameBoardArray[col + 1][row] == capturablePiece || gameBoardArray[col + 1][row] == kingPiece) && (gameBoardArray[col + 2][row] == piece || gameBoardArray[col + 2][row] == helperPiece || gameBoardArray[col + 2][row] == 'c')) {
+            if ((gameBoardArray[col + 1][row] == capturablePiece || gameBoardArray[col + 1][row] == kingPiece) && (gameBoardArray[col + 2][row] == piece || gameBoardArray[col + 2][row] == helperPiece || gameBoardArray[col + 2][row] == restricted)) {
                 capturedPieceCol.add(col + 1);
                 capturedPieceRow.add(row);
             }
         }
         if (row-2 >= 0) {
-            if ((gameBoardArray[col][row - 1] == capturablePiece || gameBoardArray[col][row - 1] == kingPiece) && (gameBoardArray[col][row - 2] == piece || gameBoardArray[col][row - 2] == helperPiece || gameBoardArray[col][row - 2] == 'c')) {
+            if ((gameBoardArray[col][row - 1] == capturablePiece || gameBoardArray[col][row - 1] == kingPiece) && (gameBoardArray[col][row - 2] == piece || gameBoardArray[col][row - 2] == helperPiece || gameBoardArray[col][row - 2] == restricted)) {
                 capturedPieceCol.add(col);
                 capturedPieceRow.add(row - 1);
             }
         }
         if (row+2 <= GRID_SIZE-1) {
-            if ((gameBoardArray[col][row + 1] == capturablePiece || gameBoardArray[col][row + 1] == kingPiece) && (gameBoardArray[col][row + 2] == piece || gameBoardArray[col][row + 2] == helperPiece || gameBoardArray[col][row + 2] == 'c')) {
+            if ((gameBoardArray[col][row + 1] == capturablePiece || gameBoardArray[col][row + 1] == kingPiece) && (gameBoardArray[col][row + 2] == piece || gameBoardArray[col][row + 2] == helperPiece || gameBoardArray[col][row + 2] == restricted)) {
                 capturedPieceCol.add(col);
                 capturedPieceRow.add(row + 1);
             }

--- a/src/main/java/copenhagen/Hnefatafl.java
+++ b/src/main/java/copenhagen/Hnefatafl.java
@@ -335,26 +335,50 @@ public class Hnefatafl {
 		return hBoard;
 	}
 
+	/**
+     * This functionss gets the attack piece image address.
+     * @return This function will return the String for the attack piece image address.
+     */
 	public static String getAttackPieceAddr(){
 		return attackPieceAddr;
 	}
 
+	/**
+	 * This functionss gets the defend piece image address.
+	 * @return This function will return the String for the defend piece image address.
+	 */
 	public static String getDefendPieceAddr(){
 		return defendPieceAddr;
 	}
 
+	/**
+     * This functionss gets the king piece image address.
+     * @return This function will return the String for the king piece image address.
+     */
 	public static String getKingPieceAddr(){
 		return kingPieceAddr;
 	}
 
+	/**
+     * This functionss gets the selected attack piece image address.
+     * @return This function will return the String for the selected attack piece image address.
+     */
 	public static String getAttackSelAddr(){
 		return attackSelAddr;
 	}
 
+	/**
+     * This functionss gets the selected defend piece image address.
+     * @return This function will return the String for the selected defend piece image address.
+     */
 	public static String getDefendSelAddr(){
 		return defendSelAddr;
 	}
 
+	/**
+     * This functionss gets the selected king piece image address.
+     * @return This function will return the String for the selected king piece image address.
+     */
 	public static String getKingSelAddr(){
 		return kingSelAddr;
 	}

--- a/src/main/java/copenhagen/Hnefatafl.java
+++ b/src/main/java/copenhagen/Hnefatafl.java
@@ -346,6 +346,8 @@ public class Hnefatafl {
 	public static void whiteStart(){
 		attackPieceAddr = whitePieceAddr;
 		defendPieceAddr = blackPieceAddr;
+		attackSelAddr = whiteSelAddr;
+		defendSelAddr = blackSelAddr;
 		blackStart = false;
 	}
 
@@ -355,6 +357,8 @@ public class Hnefatafl {
 	public static void blackStart(){
 		attackPieceAddr = blackPieceAddr;
 		defendPieceAddr = whitePieceAddr;
+		attackSelAddr = blackSelAddr;
+		defendSelAddr = whiteSelAddr;
 		setBlackStartBoolean(true);
 	}
 

--- a/src/main/java/copenhagen/Hnefatafl.java
+++ b/src/main/java/copenhagen/Hnefatafl.java
@@ -50,12 +50,17 @@ public class Hnefatafl {
 	private static boolean pieceIsSelected = false;
 	private static char winner;
 	private static FinalMenu finalMenu;
-	private static String attackPieceAddr = "images/blackpiece.png";
-	private static String defendPieceAddr = "images/whitepiece.png";
+	private static String blackPieceAddr = "images/blackpiece.png";
+	private static String whitePieceAddr = "images/whitepiece.png";
 	private static String kingPieceAddr = "images/king.png";
-	private static String attackSelAddr = "images/blackpieceSelected.png";
-	private static String defendSelAddr = "images/whitepieceSelected.png";
+	private static String blackSelAddr = "images/blackpieceSelected.png";
+	private static String whiteSelAddr = "images/whitepieceSelected.png";
 	private static String kingSelAddr = "images/kingSelected.png";
+	private static String attackPieceAddr;
+	private static String defendPieceAddr;
+	private static String attackSelAddr;
+	private static String defendSelAddr;
+	private static boolean blackStart = true;
 
     /**
      * This is the main method which starts the program.
@@ -336,7 +341,33 @@ public class Hnefatafl {
 	}
 
 	/**
-     * This functionss gets the attack piece image address.
+	 * This function makes the attack pieces white and the defend pieces black.
+	 */
+	public static void whiteStart(){
+		attackPieceAddr = whitePieceAddr;
+		defendPieceAddr = blackPieceAddr;
+		blackStart = false;
+	}
+
+	/**
+	 * This function makes the attack pieces black and the defend pieces white.
+	 */
+	public static void blackStart(){
+		attackPieceAddr = blackPieceAddr;
+		defendPieceAddr = whitePieceAddr;
+		blackStart = true;
+	}
+
+	/**
+	 * This function gets the boolean for whether the black pieces start/attack.
+	 * @return This function returns the boolean for whether black starts/attacks.
+	 */
+	public static boolean getBlackStartBoolean(){
+		return blackStart;
+	}
+
+	/**
+     * This function gets the attack piece image address.
      * @return This function will return the String for the attack piece image address.
      */
 	public static String getAttackPieceAddr(){
@@ -344,7 +375,7 @@ public class Hnefatafl {
 	}
 
 	/**
-	 * This functionss gets the defend piece image address.
+	 * This function gets the defend piece image address.
 	 * @return This function will return the String for the defend piece image address.
 	 */
 	public static String getDefendPieceAddr(){
@@ -352,7 +383,7 @@ public class Hnefatafl {
 	}
 
 	/**
-     * This functionss gets the king piece image address.
+     * This function gets the king piece image address.
      * @return This function will return the String for the king piece image address.
      */
 	public static String getKingPieceAddr(){
@@ -360,7 +391,7 @@ public class Hnefatafl {
 	}
 
 	/**
-     * This functionss gets the selected attack piece image address.
+     * This function gets the selected attack piece image address.
      * @return This function will return the String for the selected attack piece image address.
      */
 	public static String getAttackSelAddr(){
@@ -368,7 +399,7 @@ public class Hnefatafl {
 	}
 
 	/**
-     * This functionss gets the selected defend piece image address.
+     * This function gets the selected defend piece image address.
      * @return This function will return the String for the selected defend piece image address.
      */
 	public static String getDefendSelAddr(){
@@ -376,7 +407,7 @@ public class Hnefatafl {
 	}
 
 	/**
-     * This functionss gets the selected king piece image address.
+     * This function gets the selected king piece image address.
      * @return This function will return the String for the selected king piece image address.
      */
 	public static String getKingSelAddr(){

--- a/src/main/java/copenhagen/Hnefatafl.java
+++ b/src/main/java/copenhagen/Hnefatafl.java
@@ -33,7 +33,12 @@ public class Hnefatafl {
 	private static boolean saved = true;
 	private static int boardSize = 11;
 	private static int turnCount = 1;
-	private static char turn = 'b';
+	private static char attackers = 'b';
+	private static char defenders = 'w';
+	private static char king = 'k';
+	private static char empty = '0';
+	private static char restricted = 'c';
+	private static char turn = attackers;
 	private static GameBoard hBoard;
   	private static SideBar sBar;
 	private static int[] primaryColor = {244,164,96};
@@ -102,16 +107,16 @@ public class Hnefatafl {
      * w = white = king and his defenders
      */
 	public static int endTurn() {
-	    if (turn == 'b') {
-	        turn = 'w';
+	    if (turn == attackers) {
+	        turn = defenders;
         }
-        else if (turn == 'w') {
-	        turn = 'b';
+        else if (turn == defenders) {
+	        turn = attackers;
         }
 		turnCount++;
 		BottomBar.updateTurnInfo(turn, turnCount);
 		winner = GameLogic.checkWinner();
-		if (winner != '0') {
+		if (winner != empty) {
 			finalMenu = new FinalMenu(winner);
 		}
 		saved = false;
@@ -120,7 +125,7 @@ public class Hnefatafl {
 
     /**
      * This is a getter that gets whose turn it currently is.
-     * @return This function will return 'b' if it is the attackers turn or 'w' if it is the defenders turn.
+     * @return This function will return 'attackers' if it is the attackers turn or 'defenders' if it is the defenders' turn.
      */
     public static char getTurn() {
 	    return turn;
@@ -171,7 +176,7 @@ public class Hnefatafl {
 			}
 		}
 		// moves piece if appropriate
-		if((chosenSquaresPiece == '0' || chosenSquaresPiece == 'c') && pieceIsSelected){
+		if((chosenSquaresPiece == empty || chosenSquaresPiece == restricted) && pieceIsSelected){
 			movePiece(c,r);
 		}
 		selectNew(clickedOn,c,r);
@@ -194,8 +199,33 @@ public class Hnefatafl {
 		}
 	}
 
-    
-
+	/**
+     * This function sets the icon of a particular button.
+     * @param pieceType The value of the piece from the characters specified in GameBoard.java.
+     * @param button The button to add the image to.
+     */
+	public static void setButtonImage(char pieceType, JButton button){
+		try {
+			Image img;
+			ImageIcon icon;
+			if(pieceType == attackers){
+				img = ImageIO.read(Hnefatafl.class.getResource("images/blackpiece.png"));
+				icon = new ImageIcon(img);
+				button.setIcon(icon);
+			}else if(pieceType == defenders){
+				img = ImageIO.read(Hnefatafl.class.getResource("images/whitePiece.png"));
+				icon = new ImageIcon(img);
+				button.setIcon(icon);
+			}else if(pieceType == king){
+				img = ImageIO.read(Hnefatafl.class.getResource("images/king.png"));
+				icon = new ImageIcon(img);
+				button.setIcon(icon);
+			}
+		} catch (IOException e) {
+			System.out.println("Image Didn't Load");
+			System.exit(1);
+		}
+	}
 
     /**
      * This function sets a new game piece to the selected game piece.
@@ -213,15 +243,15 @@ public class Hnefatafl {
 			Image img;
 			ImageIcon icon;
 			pieceIsSelected = true;
-			if(piece == 'b' && turn == 'b'){
+			if(piece == attackers && turn == attackers){
 				img = ImageIO.read(Hnefatafl.class.getResource("images/blackpieceSelected.png"));
 				icon = new ImageIcon(img);
 				clickedOn.setIcon(icon);
-			}else if(piece == 'w' && turn == 'w'){
+			}else if(piece == defenders && turn == defenders){
 				img = ImageIO.read(Hnefatafl.class.getResource("images/whitepieceSelected.png"));
 				icon = new ImageIcon(img);
 				clickedOn.setIcon(icon);
-			}else if(piece == 'k' && turn == 'w'){
+			}else if(piece == king && turn == defenders){
 				img = ImageIO.read(Hnefatafl.class.getResource("images/kingSelected.png"));
 				icon = new ImageIcon(img);
 				clickedOn.setIcon(icon);
@@ -270,7 +300,7 @@ public class Hnefatafl {
 	 */
 	public static int newGameResetTurns(){
 		turnCount = 1;
-		turn = 'b';
+		turn = attackers;
 		saved = true;
 		return turnCount;
 	}

--- a/src/main/java/copenhagen/Hnefatafl.java
+++ b/src/main/java/copenhagen/Hnefatafl.java
@@ -50,6 +50,12 @@ public class Hnefatafl {
 	private static boolean pieceIsSelected = false;
 	private static char winner;
 	private static FinalMenu finalMenu;
+	private static String attackPieceAddr = "images/blackpiece.png";
+	private static String defendPieceAddr = "images/whitepiece.png";
+	private static String kingPieceAddr = "images/king.png";
+	private static String attackSelAddr = "images/blackpieceSelected.png";
+	private static String defendSelAddr = "images/whitepieceSelected.png";
+	private static String kingSelAddr = "images/kingSelected.png";
 
     /**
      * This is the main method which starts the program.
@@ -209,15 +215,15 @@ public class Hnefatafl {
 			Image img;
 			ImageIcon icon;
 			if(pieceType == attackers){
-				img = ImageIO.read(Hnefatafl.class.getResource("images/blackpiece.png"));
+				img = ImageIO.read(Hnefatafl.class.getResource(attackPieceAddr));
 				icon = new ImageIcon(img);
 				button.setIcon(icon);
 			}else if(pieceType == defenders){
-				img = ImageIO.read(Hnefatafl.class.getResource("images/whitePiece.png"));
+				img = ImageIO.read(Hnefatafl.class.getResource(defendPieceAddr));
 				icon = new ImageIcon(img);
 				button.setIcon(icon);
 			}else if(pieceType == king){
-				img = ImageIO.read(Hnefatafl.class.getResource("images/king.png"));
+				img = ImageIO.read(Hnefatafl.class.getResource(kingPieceAddr));
 				icon = new ImageIcon(img);
 				button.setIcon(icon);
 			}
@@ -244,15 +250,15 @@ public class Hnefatafl {
 			ImageIcon icon;
 			pieceIsSelected = true;
 			if(piece == attackers && turn == attackers){
-				img = ImageIO.read(Hnefatafl.class.getResource("images/blackpieceSelected.png"));
+				img = ImageIO.read(Hnefatafl.class.getResource(attackSelAddr));
 				icon = new ImageIcon(img);
 				clickedOn.setIcon(icon);
 			}else if(piece == defenders && turn == defenders){
-				img = ImageIO.read(Hnefatafl.class.getResource("images/whitepieceSelected.png"));
+				img = ImageIO.read(Hnefatafl.class.getResource(defendSelAddr));
 				icon = new ImageIcon(img);
 				clickedOn.setIcon(icon);
 			}else if(piece == king && turn == defenders){
-				img = ImageIO.read(Hnefatafl.class.getResource("images/kingSelected.png"));
+				img = ImageIO.read(Hnefatafl.class.getResource(kingSelAddr));
 				icon = new ImageIcon(img);
 				clickedOn.setIcon(icon);
 			}else{
@@ -322,10 +328,34 @@ public class Hnefatafl {
 	}
 
     /**
-     * This functions gets the HBoard.
+     * This functionss gets the HBoard.
      * @return This function will return the jPanel that is displayed to the user of the current gameboard.
      */
 	public static GameBoard getHBoard(){
 		return hBoard;
+	}
+
+	public static String getAttackPieceAddr(){
+		return attackPieceAddr;
+	}
+
+	public static String getDefendPieceAddr(){
+		return defendPieceAddr;
+	}
+
+	public static String getKingPieceAddr(){
+		return kingPieceAddr;
+	}
+
+	public static String getAttackSelAddr(){
+		return attackSelAddr;
+	}
+
+	public static String getDefendSelAddr(){
+		return defendSelAddr;
+	}
+
+	public static String getKingSelAddr(){
+		return kingSelAddr;
 	}
 }

--- a/src/main/java/copenhagen/Hnefatafl.java
+++ b/src/main/java/copenhagen/Hnefatafl.java
@@ -355,7 +355,14 @@ public class Hnefatafl {
 	public static void blackStart(){
 		attackPieceAddr = blackPieceAddr;
 		defendPieceAddr = whitePieceAddr;
-		blackStart = true;
+		setBlackStartBoolean(true);
+	}
+
+	/**
+	 * This function sets the boolean for if black starts/attacks
+	 */
+	public static void setBlackStartBoolean(boolean bStart){
+		blackStart = bStart;
 	}
 
 	/**

--- a/src/main/java/copenhagen/Hnefatafl.java
+++ b/src/main/java/copenhagen/Hnefatafl.java
@@ -56,10 +56,10 @@ public class Hnefatafl {
 	private static String blackSelAddr = "images/blackpieceSelected.png";
 	private static String whiteSelAddr = "images/whitepieceSelected.png";
 	private static String kingSelAddr = "images/kingSelected.png";
-	private static String attackPieceAddr;
-	private static String defendPieceAddr;
-	private static String attackSelAddr;
-	private static String defendSelAddr;
+	private static String attackPieceAddr = blackPieceAddr;
+	private static String defendPieceAddr = whitePieceAddr;
+	private static String attackSelAddr = blackSelAddr;
+	private static String defendSelAddr = whiteSelAddr;
 	private static boolean blackStart = true;
 
     /**

--- a/src/main/java/copenhagen/MainMenu.java
+++ b/src/main/java/copenhagen/MainMenu.java
@@ -15,7 +15,6 @@ public class MainMenu {
     private JButton _loadGameButton = new JButton("Load Saved Game");
     private JButton _howToPlayButton =  new JButton("How to Play");
     private JButton _settingsButton = new JButton("Settings (Not yet working)");
-    private static int boardSize = 11;
 
 
     /**
@@ -52,9 +51,7 @@ public class MainMenu {
     private class newGameListener implements  ActionListener {
         public void actionPerformed(ActionEvent e) {
             _mainMenuFrame.dispose();
-            GameLogic.setStartingPieces(boardSize);
-            Hnefatafl.setUpGameBoard();
-            Hnefatafl.displayGameBoard();
+            new BlackWhiteStart();
         }
     }
 

--- a/src/main/java/copenhagen/SaveAndLoad.java
+++ b/src/main/java/copenhagen/SaveAndLoad.java
@@ -12,6 +12,11 @@ import javax.swing.filechooser.*;
  * This class deals with all logic when it comes to saving and loading game files.
  */
 public class SaveAndLoad {
+	private static char attackers = 'b';
+	private static char defenders = 'w';
+	private static char king = 'k';
+	private static char empty = '0';
+	private static char restricted = 'c';
 
     /**
      * This function saves the present game state to a save file.
@@ -34,15 +39,15 @@ public class SaveAndLoad {
 			int userSelection = fileChooser.showSaveDialog(parentFrame);
 
 			if (userSelection == JFileChooser.APPROVE_OPTION) {
-				
+
 				game = fileChooser.getSelectedFile();
 				String filename = game.toString();
-				
+
 				if(!filename.endsWith(".hnef")){
 					game =  new File(filename + ".hnef");
 				}
-				
-				
+
+
 				System.out.println("Save as file: " + game.getAbsolutePath());
 				writer = new PrintWriter(game, "UTF-8");
 				writer.println(turnCount);
@@ -91,7 +96,7 @@ public class SaveAndLoad {
 			else {
 			    return null;
             }
-			String extension = ""; 									
+			String extension = "";
 			String name = fileName.toString();
 			int i = name.lastIndexOf('.');
 			if (i > 0) {
@@ -165,13 +170,13 @@ public class SaveAndLoad {
 		if(turnCount < 1){
 			return false;
 		}
-		
+
 		//check turn
-		if(turn == 'b' || turn == 'w');
+		if(turn == attackers || turn == defenders);
 		else{
 			return false;
 		}
-		
+
 		//count pieces
 		int b = 0;
 		int w = 0;
@@ -180,25 +185,25 @@ public class SaveAndLoad {
 		for(int i = 0; i < size; i++){
 			for(int j = 0; j < size; j++){
 				pieces[i][j] = layout.charAt((i*size)+j);
-				if(pieces[i][j] == 'b'){
+				if(pieces[i][j] == attackers){
 					b++;
 				}
-				else if(pieces[i][j] == 'w'){
+				else if(pieces[i][j] == defenders){
 					w++;
 				}
-				else if(pieces[i][j] == 'k'){
+				else if(pieces[i][j] == king){
 					k++;
 				}
-				else if(pieces[i][j] == 'c'){
+				else if(pieces[i][j] == restricted){
 					c++;
 				}
-				else if(pieces[i][j] == '0');
+				else if(pieces[i][j] == empty);
 				else{
 					return false;
 				}
 			}
 		}
-		
+
 		//check corner tiles
 		if(c != 5 && c != 4){
 			return false;

--- a/src/main/java/copenhagen/SaveAndLoad.java
+++ b/src/main/java/copenhagen/SaveAndLoad.java
@@ -52,6 +52,7 @@ public class SaveAndLoad {
 				writer = new PrintWriter(game, "UTF-8");
 				writer.println(turnCount);
 				writer.println(turn);
+				writer.println(Hnefatafl.getBlackStartBoolean());
 				for(int i = 0; i < size; i++){
 					for(int j = 0; j < size; j++){
 						writer.print(GameLogic.gameBoardArray[i][j]);
@@ -119,6 +120,16 @@ public class SaveAndLoad {
 					savedCurrentTurn = currentLine.charAt(0);
 				}
 				else if(i == 2){
+					boolean savedBool = Boolean.valueOf(currentLine);
+					Hnefatafl.setBlackStartBoolean(savedBool);
+					if (Hnefatafl.getBlackStartBoolean()) {
+						Hnefatafl.blackStart();
+					}
+					else {
+						Hnefatafl.whiteStart();
+					}
+				}
+				else if(i == 3){
 					savedLayout = currentLine;
 				}
 				i++;

--- a/src/main/java/copenhagen/SideBar.java
+++ b/src/main/java/copenhagen/SideBar.java
@@ -15,6 +15,11 @@ public class SideBar {
     private static final int buttonHeight = 40;
     private static final int startEndGap = 60;
     private static final int midGap = 70;
+    private static char attackers = 'b';
+	private static char defenders = 'w';
+	private static char king = 'k';
+	private static char empty = '0';
+	private static char restricted = 'c';
     private Color primaryColor;
     private Color secondaryColor;
     private Color letteringColor;
@@ -60,7 +65,7 @@ public class SideBar {
         newGame = new JButton("New Game");
         styleButton(newGame, midGap);
 		newGame.addActionListener(new newListener());
-		
+
         saveGame = new JButton("Save Game");
         styleButton(saveGame, midGap);
         saveGame.addActionListener(new SaveListener());
@@ -155,13 +160,13 @@ public class SideBar {
             int n = JOptionPane.showOptionDialog(concedeWindow, "Are you sure you want to forfeit?", "Hnefatafl", JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.WARNING_MESSAGE, null, forfeitOptions, forfeitOptions[0]);
             if (n == 0) {
                 char turn = Hnefatafl.getTurn();
-                if (turn == 'w') {
-                    new FinalMenu('b');
+                if (turn == defenders) {
+                    new FinalMenu(attackers);
                 } else {
-                    new FinalMenu('w');
+                    new FinalMenu(defenders);
                 }
             }
-            
+
         }
     }
 

--- a/src/test/java/copenhagen/HnefataflTest.java
+++ b/src/test/java/copenhagen/HnefataflTest.java
@@ -46,4 +46,18 @@ public class HnefataflTest {
     public void testNewGameResetTurns() {
         assertEquals(1, Hnefatafl.newGameResetTurns());
     }
+
+    // This test checks that getBlackStartBoolean() returns true when blackStart == true.
+    @Test
+    public void testGetBlackStartBooleanTrue() {
+        Hnefatafl.setBlackStartBoolean(true);
+        assertEquals(true, Hnefatafl.getBlackStartBoolean());
+    }
+
+    // This test checks that getBlackStartBoolean() returns false when blackStart == false.
+    @Test
+    public void testGetBlackStartBooleanFalse() {
+        Hnefatafl.setBlackStartBoolean(false);
+        assertEquals(false, Hnefatafl.getBlackStartBoolean());
+    }
 }


### PR DESCRIPTION
Integrates the Black-/White-Start Menu, including all related functionality (such as opening a game that had the white pieces start/attack).  However, you still cannot access the Black-/White-Start Menu by clicking "New Game" in the SideBar; perhaps add this in the future.

Fixes magic numbers pertaining to addresses for the playing piece images, as well as the character representations for the state of each space on the board (e.g. '0' for 'empty').  These values should be represented by variables. 

Also, adds all relevant documentation and unit tests and made at least one small documentation fix.