### PR TITLE
Displaying number of pieces

### DIFF
--- a/src/main/java/copenhagen/BottomBar.java
+++ b/src/main/java/copenhagen/BottomBar.java
@@ -13,6 +13,8 @@ public class BottomBar {
     private JPanel bottom;
     private static JLabel turn;
     private static JLabel turnCount;
+    private static JLabel numOfAttackPieces;
+    private static JLabel numOfDefensePieces;
     private static char attackers = 'b';
 	private static char defenders = 'w';
     private static Clock attackersClock;
@@ -41,6 +43,7 @@ public class BottomBar {
         createPanel();
         setTurn(start);
         setTurnCount(count);
+        setRemainingPieces();
         addLabels();
     }
 
@@ -49,6 +52,7 @@ public class BottomBar {
      */
     private void createPanel() {
         bottom = new JPanel();
+        bottom.setLayout(new GridBagLayout());
         bottom.setBackground(primaryColor);
     }
 
@@ -75,13 +79,32 @@ public class BottomBar {
         turnCount.setForeground(letteringColor);
     }
 
+    private void setRemainingPieces() {
+        int attackPieces = GameLogic.getNumOfAttackersLeft();
+        int defensePieces = GameLogic.getNumOfDefendersLeft();
+        numOfAttackPieces = new JLabel("Attack (" + Hnefatafl.getAttackColor() + ") Pieces Left: " + attackPieces);
+        numOfDefensePieces = new JLabel("Defense (" + Hnefatafl.getDefenseColor() + ") Pieces Left: " + defensePieces);
+        numOfAttackPieces.setForeground(letteringColor);
+        numOfDefensePieces.setForeground(letteringColor);
+    }
+
     /**
      * This function adds the labels to the bottom panel.
      */
     private void addLabels() {
-        bottom.add(turn);
+        GridBagConstraints c = new GridBagConstraints();
+        c.fill = GridBagConstraints.HORIZONTAL;
+        c.gridx = 0;
+        c.gridy = 0;
+        bottom.add(turn, c);
         addClocks();
-        bottom.add(turnCount);
+        c.gridx = 6;
+        bottom.add(turnCount, c);
+        c.gridy = 1;
+        c. gridx = 0;
+        bottom.add(numOfAttackPieces, c);
+        c.gridx = 6;
+        bottom.add(numOfDefensePieces, c);
     }
 
     /**
@@ -96,12 +119,19 @@ public class BottomBar {
         defendersTime = defendersClock.formatClock("Defenders");
         attackersTime.setForeground(letteringColor);
         defendersTime.setForeground(letteringColor);
-        bottom.add(Box.createRigidArea(new Dimension(75, 0)));
-        bottom.add(attackersTime);
-        bottom.add(Box.createRigidArea(new Dimension(75, 0)));
-        bottom.add(defendersTime);
-        bottom.add(Box.createRigidArea(new Dimension(75, 0)));
-
+        GridBagConstraints c = new GridBagConstraints();
+        c.fill = GridBagConstraints.HORIZONTAL;
+        c.gridx = 1;
+        c.gridy = 0;
+        bottom.add(Box.createRigidArea(new Dimension(0, 0)), c);
+        c.gridx++;
+        bottom.add(attackersTime, c);
+        c.gridx++;
+        bottom.add(Box.createRigidArea(new Dimension(75, 0)), c);
+        c.gridx++;
+        bottom.add(defendersTime, c);
+        c.gridx++;
+        bottom.add(Box.createRigidArea(new Dimension(75, 0)), c);
         timer.runCountdown(attackersClock, defendersClock, attackersTime, defendersTime);
     }
 
@@ -119,6 +149,16 @@ public class BottomBar {
             turn.setText("Turn: Defenders");
         }
         turnCount.setText("Turn Number: " + i);
+    }
+
+    /**
+     * This function is called whenever a piece is captured and updates the number of pieces left.
+     */
+    public static void updateNumOfPiecesLeft() {
+        int attackPieces = GameLogic.getNumOfAttackersLeft();
+        int defensePieces = GameLogic.getNumOfDefendersLeft();
+        numOfAttackPieces.setText("Attack (" + Hnefatafl.getAttackColor() + ") Pieces Left: " + attackPieces);
+        numOfDefensePieces.setText("Defense (" + Hnefatafl.getDefenseColor() + ") Pieces Left: " + defensePieces);
     }
 
     /**
@@ -213,5 +253,4 @@ public class BottomBar {
         timer.runCountdown(attackersClock, defendersClock, attackersTime, defendersTime);
 		return;
 	}
-	
 }

--- a/src/main/java/copenhagen/GameLogic.java
+++ b/src/main/java/copenhagen/GameLogic.java
@@ -21,6 +21,8 @@ public class GameLogic{
 	private static char king = 'k';
 	private static char empty = '0';
 	private static char restricted = 'c';
+	private static int numOfAttackersLeft;
+	private static int numOfDefendersLeft;
 
     /**
      * This function checks whether a piece is allowed to be currently moved.
@@ -57,6 +59,38 @@ public class GameLogic{
     }
 
     /**
+     * This function gets the number of attackers left on the board.
+     * @return This returns the number of attackers left as an integer.
+     */
+    public static int getNumOfAttackersLeft() {
+    	return numOfAttackersLeft;
+	}
+
+    /**
+     * This function gets the number of defenders left on the board.
+     * @return This returns the number of defenders left as an integer.
+     */
+	public static int getNumOfDefendersLeft() {
+		return numOfDefendersLeft;
+	}
+
+    /**
+     * This function sets the number of attackers left on the board.
+     * @param i This parameter is the integer representing the number of attackers left.
+     */
+	public static void setNumOfAttackersLeft(int i) {
+        numOfAttackersLeft = i;
+    }
+
+    /**
+     * This function sets the number of defenders left on the board.
+     * @param i This parameter is the integer representing the number of defenders left.
+     */
+    public static void setNumOfDefendersLeft(int i) {
+        numOfDefendersLeft = i;
+    }
+
+    /**
      * This function removes all the pieces that were captured on the board by the move just completed.
      * @param col This parameter is the column associated with a piece that is about to be removed.
      * @param row This parameter is the row associated with a piece that is about to be removed.
@@ -70,9 +104,16 @@ public class GameLogic{
                 // But the king is only captured if it is surrounded on all 4 (or 3 if the king is on an edge) sides
                 return;
             }
+            if (gameBoardArray[c][r] == attackers) {
+                numOfAttackersLeft--;
+            }
+            else {
+                numOfDefendersLeft--;
+            }
             gameBoardArray[c][r] = empty;
             GameBoard.removeCapturedPiecesUI(c,r);
         }
+        BottomBar.updateNumOfPiecesLeft();
     }
 
     /**
@@ -102,6 +143,8 @@ public class GameLogic{
             s[0][0] = s[0][10] = s[10][0] = s[10][10] = s[5][5] = restricted;
             s[5][5] = king;
         }
+        numOfAttackersLeft = 24;
+        numOfDefendersLeft = 12;
         gameBoardArray = s;
         return s;
     }

--- a/src/main/java/copenhagen/Hnefatafl.java
+++ b/src/main/java/copenhagen/Hnefatafl.java
@@ -81,7 +81,6 @@ public class Hnefatafl {
      * This function sets up and retrieves the different pieces (3 JPanels) that comprise the game board.
      */
 	public static void setUpGameBoard() {
-        newGameResetTurns();
         hBoard = new GameBoard(boardSize, primaryColor, secondaryColor, specialColor);
         board = hBoard.getBoard();
         sBar = new SideBar(primaryColor, secondaryColor, letteringColor);
@@ -269,10 +268,8 @@ public class Hnefatafl {
      * @return The return value is a boolean representing success or failure
      */
 	public static boolean loadGame(SaveAndLoad sl) {
-		
 		File loadFile = sl.load();
 		if(loadFile == null){
-			Settings.setDefaults();
 			return false;
 		}
 		return true;

--- a/src/main/java/copenhagen/MainMenu.java
+++ b/src/main/java/copenhagen/MainMenu.java
@@ -63,6 +63,7 @@ public class MainMenu {
         public void actionPerformed(ActionEvent e) {
             _mainMenuFrame.dispose();
             GameLogic.setStartingPieces(Hnefatafl.getBoardSize());
+            Hnefatafl.newGameResetTurns();
             Hnefatafl.setUpGameBoard();
             Hnefatafl.displayGameBoard();            
         }

--- a/src/main/java/copenhagen/SaveAndLoad.java
+++ b/src/main/java/copenhagen/SaveAndLoad.java
@@ -256,6 +256,9 @@ public class SaveAndLoad {
 		}
 
 		GameLogic.gameBoardArray = pieces;
+		GameLogic.setNumOfAttackersLeft(b);
+		GameLogic.setNumOfDefendersLeft(w);
+		BottomBar.updateNumOfPiecesLeft();
 		Hnefatafl.changeTimes(aTime, dTime);
 		Hnefatafl.setTurn(turn);
 		Hnefatafl.setTurnCount(turnCount);

--- a/src/main/java/copenhagen/SaveAndLoad.java
+++ b/src/main/java/copenhagen/SaveAndLoad.java
@@ -91,6 +91,8 @@ public class SaveAndLoad {
 		String savedLayout = "";
 		String aTime = "";
 		String dTime = "";
+        String savedAttackColor = "";
+        String savedDefenseColor = "";
 		try {
 			JFileChooser fileChooser = new JFileChooser();
 			FileNameExtensionFilter filter = new FileNameExtensionFilter("hnef","hnef");
@@ -125,12 +127,10 @@ public class SaveAndLoad {
 					savedCurrentTurn = currentLine.charAt(0);
 				}
 				else if(i == 2){
-					String savedAttackColor = String.valueOf(currentLine);
-					Hnefatafl.setAttackColor(savedAttackColor);
-				}
+					savedAttackColor = String.valueOf(currentLine);
+                }
 				else if(i == 3){
-					String savedDefenseColor = String.valueOf(currentLine);
-					Hnefatafl.setDefenseColor(savedDefenseColor);
+					savedDefenseColor = String.valueOf(currentLine);
 				}
 				else if(i == 4){
 					aTime = currentLine;
@@ -157,8 +157,10 @@ public class SaveAndLoad {
                 return null;
 			}
 		}
-		if(checkState(savedLayout, savedCurrentTurn, savedTurnCount, aTime, dTime) == true){
-			return fileName;
+		if(checkState(savedLayout, savedCurrentTurn, savedTurnCount, aTime, dTime)){
+            Hnefatafl.setAttackColor(savedAttackColor);
+            Hnefatafl.setDefenseColor(savedDefenseColor);
+            return fileName;
 		}
 		else{
             JOptionPane.showMessageDialog(null, "Invalid save file.");

--- a/src/main/java/copenhagen/Settings.java
+++ b/src/main/java/copenhagen/Settings.java
@@ -137,6 +137,8 @@ public class Settings {
         minute = 5;
         second = 0;
         additionalTimePerMove = 3;
+        BottomBar.setStartingTime(second, minute, hour);
+        BottomBar.setPerMoveTime(additionalTimePerMove);
     }
 
     /**

--- a/src/main/java/copenhagen/SideBar.java
+++ b/src/main/java/copenhagen/SideBar.java
@@ -116,6 +116,7 @@ public class SideBar {
            int n = JOptionPane.showOptionDialog(new JFrame(), "Are you sure you want to begin a new game? All progress wil be lost.", "Hnefatafl", JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.WARNING_MESSAGE, null, options, options[0]);
            if (n == 0) {
                Hnefatafl.removeOldGameBoard();
+               Settings.setDefaults();
                new MainMenu();
            }
            if (n == 1) {

--- a/src/main/java/copenhagen/SideBar.java
+++ b/src/main/java/copenhagen/SideBar.java
@@ -173,7 +173,9 @@ public class SideBar {
      */
      private class ExitListener implements ActionListener {
        public void actionPerformed(ActionEvent e) {
-           
+           if (Hnefatafl.getSaved()) {
+               System.exit(0);
+           }
            Object[] options = {"Save", "Don't Save", "Cancel"};
            int n = JOptionPane.showOptionDialog(new JFrame(), "Want to save your game progress?", "Hnefatafl", JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.WARNING_MESSAGE, null, options, options[0]);
            if (n == 0) {


### PR DESCRIPTION
This now displays the number of pieces left on each side in the bottom bar underneath everything that currently is already there.

When making sure that the number of pieces left was displayed properly when loading a file, I noticed a defect that has been there probably since the timers were implemented.

DEFECT: loading a saved game and then starting up a new game does not create new timers and the game will end prematurely. What is displayed and the timer actually is does not match up.