### PR TITLE
Add "Draw" feature

### DIFF
--- a/src/main/java/copenhagen/BottomBar.java
+++ b/src/main/java/copenhagen/BottomBar.java
@@ -75,6 +75,7 @@ public class BottomBar {
      * @param i This tells what turn the game is currently on.
      */
     private void setTurnCount(int i) {
+        i = (int) Math.ceil((double) i/2);
         turnCount = new JLabel("Turn Number: " + i);
         turnCount.setForeground(letteringColor);
     }
@@ -156,6 +157,7 @@ public class BottomBar {
      * @param i This parameter is the current turn number.
      */
     public static void updateTurnInfo(char c, int i) {
+        i = (int) Math.ceil((double) i/2);
         updateClock(c);
         if (c == attackers) {
             turn.setText("Turn: Attackers");

--- a/src/main/java/copenhagen/FinalMenu.java
+++ b/src/main/java/copenhagen/FinalMenu.java
@@ -4,19 +4,18 @@ import java.awt.*;
 import javax.swing.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.image.BufferedImage;
+import javax.imageio.ImageIO;
+import java.io.IOException;
+
 
 /**
  * This class is used for displaying the options a user has after a game of hnefatafl has finished.
  */
 public class FinalMenu {
-	private JFrame menuFrame;
-	private JPanel menu;
-	private JPanel buttonPanel;
-	private JButton newGameBtn;
-	private JButton mainMenuBtn;
-	private JLabel text;
-	private JLabel winnerText;
+    private static char attackers = 'b';
 	private static char defenders = 'w';
+    private static char draw = 'd';
 
     /**
      * This function calls a function to create the final menu.
@@ -32,94 +31,96 @@ public class FinalMenu {
      */
 	private void createMenu(char winningSide) {
         BottomBar.getTimer().stopCountDown();
+        JPanel content = new JPanel();
+        content.setLayout(new GridBagLayout());
+        content.setPreferredSize(new Dimension(250, 250));
+        int fontSize = 40;
+        JLabel [] winnerText;
         
-		String winner;
 		if (winningSide == defenders) {
-			winner = "DEFENDERS";
-		} else {
-			winner = "ATTACKERS";
-		}
+            winnerText = createLabel("DEFENDERS WIN",Hnefatafl.getDefendPieceAddr());
+		} else if (winningSide == attackers){
+			winnerText = createLabel("ATTACKERS WIN",Hnefatafl.getAttackPieceAddr());
+        } else {
+            String winMessage = "DRAW!"+"<br>"+"<br>"+"<font size=\"-2\">Fifty(50) moves were made"+"<br>"+"without a capture"+"<br>"+"<br>"+"<br>"+"<font size=\"+3\">Nobody WINS</font>";
+            winnerText = createLabel(winMessage,"none");
+        }
+		winnerText[0].setFont(new Font("Courier", Font.PLAIN, fontSize));
 
-		menuFrame = new JFrame();
-		menuFrame.setSize(new Dimension(400, 200));
-
-		menu = new JPanel();
-		buttonPanel = new JPanel();
-
-		text = new JLabel("Game Over!\n\n");
-		text.setFont(new Font("Courier", Font.PLAIN, 30));
-		winnerText = new JLabel(winner + " WIN\n\n");
-		winnerText.setFont(new Font("Courier", Font.PLAIN, 40));
-
-		addButtons();
-
-		menu.add(text, BorderLayout.CENTER);
-		menu.add(winnerText, BorderLayout.CENTER);
-		menu.add(buttonPanel, BorderLayout.SOUTH);
-		menuFrame.add(menu, BorderLayout.CENTER);
-
-		showMenu();
+        content.add(displayPicturesAndCaption(winnerText),createGridBagConstraints(0, 0));
+        Object[] options = {"Quit","New Game"};
+        int n = JOptionPane.showOptionDialog(null, content, "Hnefatafl",
+                                      JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE, null, options, options[0]);
+        if (n == 1) {
+            Hnefatafl.removeOldGameBoard();
+            Settings.setDefaults();
+            new MainMenu();
+        }
+        if (n == 0) {
+            System.exit(0);
+        }
 	}
-
     /**
-     * This methods displays the final menu to the user.
+     * This function creates the final message labels that will be displayed at the end of a game. 
+     * If the game does not end in a draw, the winning side's piece is displayed.
+     * @param text This parameter is the message that will be displayed
+     * @param imageAddress This parameter is the image address of the winning side
      */
-	private void showMenu() {
-		menuFrame.setLocationRelativeTo(null);
-		menuFrame.setVisible(true);
-		menuFrame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
-	}
 
+    private JLabel[] createLabel(String text, String imageAddress) {
+        if(imageAddress.equals("none")){
+            return(new JLabel[] {new JLabel(("<html><div style='text-align: center;'>" + text + "<br>" +"</div></html>"))});
+        } else {
+            return(new JLabel[] {new JLabel(("<html><div style='text-align: center;'>" + text + "<br>" +"</div></html>")),getImage(imageAddress)});
+        }
+    }
+
+    
     /**
-     * This method adds the various buttons to the final menu.
+     * This function creates the necessary GridBagConstraints for putting things within a GridBagLayout panel.
+     * @param x This parameter is the value for gridx attribute of the GridBagConstraints variable.
+     * @param y This parameter is the value for gridy attribute of the GridBagConstraints variable.
+     * @return This function returns the newly created GridBagConstraints object.
      */
-	private void addButtons() {
-		newGameBtn = new JButton("New Game");
-		newGameBtn.addActionListener(new newListener());
-
-		mainMenuBtn = new JButton("Exit Game");
-		mainMenuBtn.addActionListener(new mainMenuListener());
-
-		buttonPanel.add(newGameBtn);
-		buttonPanel.add(mainMenuBtn);
-	}
-
-	/**
-	 * This is a button listener for when the new game button is clicked. It will prompt the user to confirm.
-	 * If the user confirms, it will class a new game function to reset the board and begin a new game.
-	 */
-	private class newListener implements ActionListener {
-		public void actionPerformed(ActionEvent e) {
-			Object[] options = {"Confirm", "Cancel"};
-			int n = JOptionPane.showOptionDialog(new JFrame(), "Are you sure you want to begin a new game?", "Hnefatafl", JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.WARNING_MESSAGE, null, options, options[0]);
-			if (n == 0) {
-                Hnefatafl.removeOldGameBoard();
-                Settings.setDefaults();
-                menuFrame.dispose();
-				new MainMenu();
-			}
-			if (n == 1) {
-				return;
-			}
-
-		}
-	}
-
-	/**
-	 * This is a button listener for when the main menu button is clicked. It will prompt the user to confirm.
-	 * If the user confirms, it will class a new game function to reset the board and begin a new game.
-	 */
-	private class mainMenuListener implements ActionListener {
-		public void actionPerformed(ActionEvent e) {
-			Object[] options = {"Confirm", "Cancel"};
-			int n = JOptionPane.showOptionDialog(new JFrame(), "Are you sure you want to exit?", "Hnefatafl", JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.WARNING_MESSAGE, null, options, options[0]);
-			if (n == 0) {
-				System.exit(0);
-			}
-			if (n == 1) {
-				return;
-			}
-
-		}
-	}
+    public static GridBagConstraints createGridBagConstraints(int x, int y) {
+        GridBagConstraints c = new GridBagConstraints();
+        c.fill = GridBagConstraints.HORIZONTAL;
+        c.gridx = x;
+        c.gridy = y;
+        c.weightx = 0;
+        c.weighty = 0;
+        return c;
+    }
+    
+    /**
+     * This function creates a GridBagLayout JPanel that contains the given picture(s) and captions.
+     * @param items This parameter is an array of JLabels which contains the picture(s) and the caption associated with
+     *              it.
+     * @return This function returns the created JPanel which will go into the bigger overall JPanel.
+     */
+    public static JPanel displayPicturesAndCaption(JLabel[] items) {
+        int x = 0;
+        JPanel panel = new JPanel();
+        panel.setLayout(new GridBagLayout());
+        for (int y = 0; y < items.length; y++) {
+            panel.add(items[y], createGridBagConstraints(x, y));
+        }
+        return panel;
+    }
+    
+    /**
+     * This function grabs an image and puts it into a JLabel to later then be put in the JPanel.
+     * @param s This parameter is the path of where the image is located at.
+     * @return This function returns a JLabel representation of the image.
+     */
+    public JLabel getImage(String s) {
+        try {
+            BufferedImage image = ImageIO.read(Hnefatafl.class.getResource(s));
+            JLabel result = new JLabel(new ImageIcon(image), SwingConstants.CENTER);
+            return result;
+        }
+        catch (IOException e) {
+            return  null;
+        }
+    }
 }

--- a/src/main/java/copenhagen/GameLogic.java
+++ b/src/main/java/copenhagen/GameLogic.java
@@ -222,13 +222,26 @@ public class GameLogic{
      * winner)
      */
 	public static char checkWinner(char turn) {
-        if (Hnefatafl.getTurnCount() == 49)
+
+        if (checkDraw() == draw)
             return draw;
 		if (turn == attackers)
 			return checkAttackWin();
 		else
 			return checkDefendWin();
 	}
+    
+    /**
+     * This function checks to see if there is a draw at the end of each turn.
+     *
+     * @return This function returns the whether or not a draw has happened. ('d' if there is a draw; otherwise '0' if no draw)
+     */
+    public static char checkDraw() {
+        if (Hnefatafl.getTurnCount() == 49)
+            return draw;
+        else
+            return empty;
+    }
 
     /**
      * This function checks if the attacking team has won.

--- a/src/main/java/copenhagen/GameLogic.java
+++ b/src/main/java/copenhagen/GameLogic.java
@@ -18,6 +18,7 @@ public class GameLogic{
     public static char[][] gameBoardArray;
     private static char attackers = 'b';
 	private static char defenders = 'w';
+    private static char draw = 'd';
 	private static char king = 'k';
 	private static char empty = '0';
 	private static char restricted = 'c';
@@ -119,6 +120,7 @@ public class GameLogic{
             gameBoardArray[c][r] = empty;
             GameBoard.removeCapturedPiecesUI(c,r);
         }
+		Hnefatafl.captureResetTurnCount();
         BottomBar.updateNumOfPiecesLeft();
     }
 
@@ -220,6 +222,8 @@ public class GameLogic{
      * winner)
      */
 	public static char checkWinner(char turn) {
+        if (Hnefatafl.getTurnCount() == 49)
+            return draw;
 		if (turn == attackers)
 			return checkAttackWin();
 		else

--- a/src/main/java/copenhagen/GameLogic.java
+++ b/src/main/java/copenhagen/GameLogic.java
@@ -221,9 +221,9 @@ public class GameLogic{
      * @return This function returns the results of which side won if anyone did. ('b' or 'w'; otherwise '0' if no
      * winner)
      */
-	public static char checkWinner(char turn) {
+	public static char checkWinner(char turn, int i) {
 
-        if (checkDraw() == draw)
+        if (checkDraw(i) == draw)
             return draw;
 		if (turn == attackers)
 			return checkAttackWin();
@@ -236,8 +236,9 @@ public class GameLogic{
      *
      * @return This function returns the whether or not a draw has happened. ('d' if there is a draw; otherwise '0' if no draw)
      */
-    public static char checkDraw() {
-        if (Hnefatafl.getTurnCount() == 49)
+    public static char checkDraw(int i) {
+        i = (int) Math.floor((double) i/2);
+        if (i == 50)
             return draw;
         else
             return empty;

--- a/src/main/java/copenhagen/Hnefatafl.java
+++ b/src/main/java/copenhagen/Hnefatafl.java
@@ -31,7 +31,7 @@ public class Hnefatafl {
 	private static JPanel bottom;
 	private static boolean saved = true;
 	private static int boardSize = 11;
-	private static int turnCount = 1;
+	private static int turnCount = 2;
 	private static char attackers = 'b';
 	private static char defenders = 'w';
 	private static char king = 'k';
@@ -146,7 +146,7 @@ public class Hnefatafl {
      * w = white = king and his defenders
      */
 	public static int endTurn() {
-		winner = GameLogic.checkWinner(turn);
+		winner = GameLogic.checkWinner(turn, turnCount);
 	    if (turn == attackers) {
 	        turn = defenders;
         }
@@ -179,14 +179,6 @@ public class Hnefatafl {
 	    turn = c;
     }
     
-    /**
-     * This is a getter that gets the current turn number.
-     * @return This function will return the current turn number'
-     * turn.
-     */
-    public static int getTurnCount() {
-        return turnCount;
-    }
 
     /**
      * This is a setter that sets the current turn number when loading a game save.

--- a/src/main/java/copenhagen/Hnefatafl.java
+++ b/src/main/java/copenhagen/Hnefatafl.java
@@ -36,6 +36,7 @@ public class Hnefatafl {
 	private static char defenders = 'w';
 	private static char king = 'k';
 	private static char empty = '0';
+    private static char draw = 'd';
 	private static char restricted = 'c';
 	private static char turn = attackers;
 	private static GameBoard hBoard;
@@ -177,6 +178,15 @@ public class Hnefatafl {
     public static void setTurn(char c) {
 	    turn = c;
     }
+    
+    /**
+     * This is a getter that gets the current turn number.
+     * @return This function will return the current turn number'
+     * turn.
+     */
+    public static int getTurnCount() {
+        return turnCount;
+    }
 
     /**
      * This is a setter that sets the current turn number when loading a game save.
@@ -185,6 +195,15 @@ public class Hnefatafl {
     public static void setTurnCount(int i) {
 	    turnCount = i;
     }
+	
+	/**
+	 * This is a setter that resets the current turn number to 0 when one or more pieces are captured.
+	 * @param i This parameter is the turn count for the game.
+	 */
+	public static int captureResetTurnCount() {
+		turnCount = 0;
+        return turnCount;
+	}
 
     /**
      * This is a getter that gets whether the game was saved already before exiting.

--- a/src/test/java/copenhagen/GameLogicTest.java
+++ b/src/test/java/copenhagen/GameLogicTest.java
@@ -126,7 +126,7 @@ public class GameLogicTest {
 		board[0][0] = 'k';
 		GameLogic gl = new GameLogic();
 		gl.gameBoardArray = board;
-		char actual = gl.checkWinner('w');
+		char actual = gl.checkWinner('w',10);
 		assertEquals(actual, expected);
 
 	}
@@ -141,7 +141,7 @@ public class GameLogicTest {
 		board[2][2] = 'k';
 		board[2][1] = board[1][2] = board[3][2] = board[2][3] = 'b';
 		gl.gameBoardArray = board;
-		actual = gl.checkWinner('b');
+		actual = gl.checkWinner('b',10);
 		assertEquals(actual, expected);
 
 	}
@@ -156,7 +156,7 @@ public class GameLogicTest {
         hBoard[5][4] = 'k';
         hBoard[5][3] = hBoard[4][4] = hBoard[6][4] = 'b';
 		gl.gameBoardArray = hBoard;
-		char actual = gl.checkWinner('b');
+		char actual = gl.checkWinner('b',10);
         assertEquals(actual, expected);
     }
     
@@ -170,7 +170,7 @@ public class GameLogicTest {
         hBoard[5][6] = 'k';
         hBoard[5][7] = hBoard[4][6] = hBoard[6][6] = 'b';
 		gl.gameBoardArray = hBoard;
-		char actual = gl.checkWinner('b');
+		char actual = gl.checkWinner('b',10);
         assertEquals(actual, expected);
     }
     
@@ -184,7 +184,7 @@ public class GameLogicTest {
         hBoard[6][5] = 'k';
         hBoard[7][5] = hBoard[6][6] = hBoard[6][4] = 'b';
 		gl.gameBoardArray = hBoard;
-		char actual = gl.checkWinner('b');
+		char actual = gl.checkWinner('b',10);
         assertEquals(actual, expected);
     }
     
@@ -198,7 +198,7 @@ public class GameLogicTest {
         hBoard[4][5] = 'k';
         hBoard[3][5] = hBoard[4][4] = hBoard[4][6] = 'b';
 		gl.gameBoardArray = hBoard;
-		char actual = gl.checkWinner('b');
+		char actual = gl.checkWinner('b',10);
         assertEquals(actual, expected);
     }
     
@@ -214,7 +214,7 @@ public class GameLogicTest {
         hBoard[2][1] = hBoard[3][1] = hBoard[4][1] = hBoard[5][1] = hBoard[6][1] = hBoard[7][1] = hBoard[8][1] = hBoard[1][2] = hBoard[1][3] = hBoard[1][4] = hBoard[1][5] = hBoard[1][6] = hBoard[1][7] = hBoard[1][8] =hBoard[8][2] = hBoard[8][3] = hBoard[8][4] = hBoard[8][5] = hBoard[8][6] = hBoard[8][7] = hBoard[1][8] = hBoard[2][8] = hBoard[3][8] = hBoard[4][8]  = hBoard[5][8] = hBoard[6][8] = hBoard[7][8] = hBoard[8][8] = 'b';
         hBoard[5][5] = 'k';
 		gl.gameBoardArray = hBoard;
-		char actual = gl.checkWinner('b');
+		char actual = gl.checkWinner('b',10);
         assertEquals(actual, expected);
         
     }
@@ -231,7 +231,7 @@ public class GameLogicTest {
         hBoard[2][1] = hBoard[3][1] = hBoard[4][1] = hBoard[5][1] = hBoard[6][1] = hBoard[7][1] = hBoard[8][1] = hBoard[1][2] = hBoard[1][3] = hBoard[1][4] = hBoard[1][5] = hBoard[1][6] = hBoard[1][7] = hBoard[1][8] =hBoard[8][2] = hBoard[8][3] = hBoard[8][4] = hBoard[8][5] = hBoard[8][6] = hBoard[8][7] = hBoard[1][8] = hBoard[2][8] = hBoard[3][8] = hBoard[4][8]  = hBoard[5][8] = hBoard[6][8] = hBoard[7][8] = hBoard[8][8] = 'b';
         hBoard[5][10] = 'k';
 		gl.gameBoardArray = hBoard;
-		char actual = gl.checkWinner('b');
+		char actual = gl.checkWinner('b',10);
         assertEquals(actual, expected);
     }
     

--- a/src/test/java/copenhagen/HnefataflTest.java
+++ b/src/test/java/copenhagen/HnefataflTest.java
@@ -53,6 +53,12 @@ public class HnefataflTest {
     public void testNewGameResetTurns() {
         assertEquals(1, Hnefatafl.newGameResetTurns());
     }
+    
+    // This test checks that the turn count is reset when a piece is captured.
+    @Test
+    public void testCaptureResetTurnCount() {
+        assertEquals(0,Hnefatafl.captureResetTurnCount());
+    }
 
     //test that attack color is set correctly and to lowercase
     @Test

--- a/src/test/java/copenhagen/HnefataflTest.java
+++ b/src/test/java/copenhagen/HnefataflTest.java
@@ -19,7 +19,7 @@ public class HnefataflTest {
     @Test
     public void testSaveGameIfSuccessful() {
         SaveAndLoad mockedSaveAndLoad = mock(SaveAndLoad.class);
-        when(mockedSaveAndLoad.save(11, 'b', 1,"00:05:00","00:05:00")).thenReturn(true);
+        when(mockedSaveAndLoad.save(11, 'b', 2,"00:05:00","00:05:00")).thenReturn(true);
         assertEquals(true, Hnefatafl.saveGame(mockedSaveAndLoad));
     }
 
@@ -27,7 +27,7 @@ public class HnefataflTest {
     @Test
     public void testSaveGameIfUnsuccessful() {
         SaveAndLoad mockedSaveAndLoad = mock(SaveAndLoad.class);
-        when(mockedSaveAndLoad.save(11, 'b', 1,"00:05:00","00:05:00")).thenReturn(false);
+        when(mockedSaveAndLoad.save(11, 'b', 2,"00:05:00","00:05:00")).thenReturn(false);
         assertEquals(false, Hnefatafl.saveGame(mockedSaveAndLoad));
     }
 


### PR DESCRIPTION
Fixed the way it counts turns. Originally it counted each players turn
as 1. It now, correctly, increments the turn count only after both
players have played. Also, the turn count is reset when a capture is made, because we only care about how many turns since the last capture. The total number of moves is still saved in the save file and used to keep calculate the turn count. But this total number of moves is never displayed to the user.